### PR TITLE
Fix OTP verification by deleting old OTPs before creating new ones

### DIFF
--- a/api/auth/send-otp.js
+++ b/api/auth/send-otp.js
@@ -55,6 +55,9 @@ module.exports = async function handler(req, res) {
       });
     }
 
+    // Delete any existing OTP for this phone number
+    await OTPVerification.deleteMany({ phoneNumber });
+
     // Generate 6-digit OTP
     const otp = Math.floor(100000 + Math.random() * 900000).toString();
 


### PR DESCRIPTION
- Delete existing OTP records when sending a new OTP
- Prevents finding old OTP records during verification
- Ensures only the latest OTP is valid