### PR TITLE
fix: Fix parameter mismatch in GoalDetailsScreen updateGoalProgress

### DIFF
--- a/lifesyncc-mobile/app/screens/main/GoalDetailsScreen.tsx
+++ b/lifesyncc-mobile/app/screens/main/GoalDetailsScreen.tsx
@@ -67,8 +67,9 @@ export const GoalDetailsScreen: React.FC = () => {
     }
   };
 
-  const updateGoalProgress = async (newValue: number) => {
+  const updateGoalProgress = async (goalId: string, newValue: number) => {
     try {
+      // Note: goalId parameter is passed but we use the goal from state since we're in the details view
       const progressData = goal.type === 'milestone' 
         ? { progress: newValue }
         : { currentValue: newValue };


### PR DESCRIPTION
The GoalProgressModal calls onUpdate with (goalId, newValue) but GoalDetailsScreen's updateGoalProgress was expecting only (newValue), causing the goalId to be used as the progress value. Fixed by updating the function signature to match the expected interface.

This resolves the issue where progress updates were sending the goal ID as the progress value, causing server errors.

🤖 Generated with [Claude Code](https://claude.ai/code)