### PR TITLE
feat: Add recurring tasks functionality to mobile app

### DIFF
--- a/backend/routes/schedule.js
+++ b/backend/routes/schedule.js
@@ -224,12 +224,19 @@ router.post('/recurring', authMiddleware, async (req, res) => {
   try {
     const { block, startDate, daysAhead = 90 } = req.body;
     
+    console.log('Received recurring task request:', { block, startDate, daysAhead });
+    
     if (!block || !startDate) {
       return res.status(400).json({ error: 'Block and startDate are required' });
     }
     
     if (!block.recurring || !block.recurrenceRule) {
       return res.status(400).json({ error: 'Block must have recurring flag and recurrenceRule' });
+    }
+    
+    // Validate date format
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(startDate)) {
+      return res.status(400).json({ error: 'Invalid date format. Use YYYY-MM-DD' });
     }
     
     // Generate recurring instances

--- a/lifesyncc-mobile/app/screens/main/ScheduleScreenEnhanced.tsx
+++ b/lifesyncc-mobile/app/screens/main/ScheduleScreenEnhanced.tsx
@@ -24,6 +24,15 @@ import { ScheduleViewSwitcher, ScheduleViewType } from '../../components/Schedul
 import { ScheduleWeeklyView } from '../../components/ScheduleWeeklyView';
 import { ScheduleMonthlyView } from '../../components/ScheduleMonthlyView';
 
+interface RecurrenceRule {
+  type: 'daily' | 'weekly' | 'monthly' | 'custom';
+  interval?: number;
+  daysOfWeek?: number[];
+  endDate?: Date;
+  endOccurrences?: number;
+  exceptions?: Date[];
+}
+
 interface ScheduleBlock {
   id: string;
   title: string;
@@ -32,6 +41,10 @@ interface ScheduleBlock {
   endTime: string;
   completed: boolean;
   goalId?: string;
+  recurring?: boolean;
+  recurrenceRule?: RecurrenceRule;
+  recurrenceId?: string;
+  originalDate?: Date;
 }
 
 const categoryColors = {
@@ -87,7 +100,16 @@ export const ScheduleScreenEnhanced: React.FC = () => {
     category: 'personal' as const,
     startTime: '09:00',
     endTime: '10:00',
+    recurring: false,
+    recurrenceRule: {
+      type: 'weekly' as const,
+      interval: 1,
+      daysOfWeek: [] as number[],
+      endOccurrences: undefined as number | undefined,
+      endDate: undefined as Date | undefined,
+    },
   });
+  const [recurrenceEndType, setRecurrenceEndType] = useState<'never' | 'date' | 'occurrences'>('never');
 
   const formatDate = (date: Date) => {
     const options: Intl.DateTimeFormatOptions = { 
@@ -179,21 +201,59 @@ export const ScheduleScreenEnhanced: React.FC = () => {
       startTime: newTask.startTime,
       endTime: newTask.endTime,
       completed: false,
+      recurring: newTask.recurring,
+      recurrenceRule: newTask.recurring ? {
+        type: newTask.recurrenceRule.type,
+        interval: newTask.recurrenceRule.interval,
+        daysOfWeek: newTask.recurrenceRule.daysOfWeek,
+        endDate: newTask.recurrenceRule.endDate,
+        endOccurrences: newTask.recurrenceRule.endOccurrences,
+      } : undefined,
+      recurrenceId: newTask.recurring ? `rec-${Date.now()}-${Math.random().toString(36).substr(2, 9)}` : undefined,
     };
     
     try {
-      const updatedSchedule = await scheduleService.updateSchedule(
-        scheduleService.formatDateForAPI(selectedDate),
-        [...schedule, newBlock]
-      );
-      setSchedule(updatedSchedule.blocks);
-      setScheduleId(updatedSchedule._id);
+      let updatedSchedule;
+      
+      if (newTask.recurring) {
+        // For recurring tasks, use the recurring endpoint
+        const startDate = scheduleService.formatDateForAPI(selectedDate);
+        console.log('Creating recurring task with startDate:', startDate);
+        const recurringTask = {
+          block: newBlock,
+          startDate: startDate,
+        };
+        updatedSchedule = await scheduleService.createRecurringTask(recurringTask);
+        // Refresh the current day's schedule to show the new recurring task
+        const currentSchedule = await scheduleService.getSchedule(
+          scheduleService.formatDateForAPI(selectedDate)
+        );
+        setSchedule(currentSchedule.blocks || []);
+        setScheduleId(currentSchedule._id || '');
+      } else {
+        // For non-recurring tasks, use the regular update
+        updatedSchedule = await scheduleService.updateSchedule(
+          scheduleService.formatDateForAPI(selectedDate),
+          [...schedule, newBlock]
+        );
+        setSchedule(updatedSchedule.blocks);
+        setScheduleId(updatedSchedule._id);
+      }
+      
       setShowAddModal(false);
       setNewTask({
         title: '',
         category: 'personal',
         startTime: '09:00',
         endTime: '10:00',
+        recurring: false,
+        recurrenceRule: {
+          type: 'weekly',
+          interval: 1,
+          daysOfWeek: [],
+          endOccurrences: undefined,
+          endDate: undefined,
+        },
       });
     } catch (error) {
       Alert.alert('Error', 'Failed to add task');
@@ -405,9 +465,7 @@ export const ScheduleScreenEnhanced: React.FC = () => {
       >
         <View style={styles.modalContainer}>
           <View style={styles.modalContent}>
-            <Text style={[styles.modalTitle, { backgroundColor: 'red', color: 'white' }]}>
-              🚨 RECURRING TASKS COMING! 🚨
-            </Text>
+            <Text style={styles.modalTitle}>Add New Task</Text>
             
             <TextInput
               style={styles.input}
@@ -458,6 +516,84 @@ export const ScheduleScreenEnhanced: React.FC = () => {
                 />
               </View>
             </View>
+            
+            {/* Recurring Task Toggle */}
+            <View style={styles.recurringContainer}>
+              <Text style={styles.label}>Repeat</Text>
+              <TouchableOpacity
+                style={styles.recurringToggle}
+                onPress={() => setNewTask({ ...newTask, recurring: !newTask.recurring })}
+              >
+                <View style={[styles.toggleCircle, newTask.recurring && styles.toggleCircleActive]} />
+                <Text style={styles.recurringToggleText}>
+                  {newTask.recurring ? 'On' : 'Off'}
+                </Text>
+              </TouchableOpacity>
+            </View>
+            
+            {/* Recurring Options */}
+            {newTask.recurring && (
+              <View style={styles.recurrenceOptions}>
+                <Text style={styles.label}>Frequency</Text>
+                <View style={styles.frequencyButtons}>
+                  {(['daily', 'weekly', 'monthly'] as const).map((freq) => (
+                    <TouchableOpacity
+                      key={freq}
+                      style={[
+                        styles.frequencyButton,
+                        newTask.recurrenceRule.type === freq && styles.selectedFrequency,
+                      ]}
+                      onPress={() => setNewTask({
+                        ...newTask,
+                        recurrenceRule: { ...newTask.recurrenceRule, type: freq }
+                      })}
+                    >
+                      <Text style={[
+                        styles.frequencyButtonText,
+                        newTask.recurrenceRule.type === freq && styles.selectedFrequencyText,
+                      ]}>
+                        {freq.charAt(0).toUpperCase() + freq.slice(1)}
+                      </Text>
+                    </TouchableOpacity>
+                  ))}
+                </View>
+                
+                {/* Weekly Days Selection */}
+                {newTask.recurrenceRule.type === 'weekly' && (
+                  <View style={styles.daysContainer}>
+                    <Text style={styles.label}>Days of Week</Text>
+                    <View style={styles.daysButtons}>
+                      {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((day, index) => (
+                        <TouchableOpacity
+                          key={index}
+                          style={[
+                            styles.dayButton,
+                            newTask.recurrenceRule.daysOfWeek?.includes(index) && styles.selectedDay,
+                          ]}
+                          onPress={() => {
+                            const days = newTask.recurrenceRule.daysOfWeek || [];
+                            const updatedDays = days.includes(index)
+                              ? days.filter(d => d !== index)
+                              : [...days, index];
+                            setNewTask({
+                              ...newTask,
+                              recurrenceRule: { ...newTask.recurrenceRule, daysOfWeek: updatedDays }
+                            });
+                          }}
+                        >
+                          <Text style={[
+                            styles.dayButtonText,
+                            newTask.recurrenceRule.daysOfWeek?.includes(index) && styles.selectedDayText,
+                          ]}>
+                            {day}
+                          </Text>
+                        </TouchableOpacity>
+                      ))}
+                    </View>
+                  </View>
+                )}
+              </View>
+            )}
             
             <View style={styles.modalButtons}>
               <TouchableOpacity
@@ -748,5 +884,95 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     textAlign: 'center',
+  },
+  recurringContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 16,
+  },
+  recurringToggle: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#f3f4f6',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+  },
+  toggleCircle: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    backgroundColor: '#9ca3af',
+    marginRight: 8,
+  },
+  toggleCircleActive: {
+    backgroundColor: '#4F46E5',
+  },
+  recurringToggleText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#4b5563',
+  },
+  recurrenceOptions: {
+    backgroundColor: '#f9fafb',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 12,
+  },
+  frequencyButtons: {
+    flexDirection: 'row',
+    marginBottom: 16,
+  },
+  frequencyButton: {
+    flex: 1,
+    paddingVertical: 8,
+    marginHorizontal: 4,
+    borderRadius: 8,
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#e5e7eb',
+  },
+  selectedFrequency: {
+    backgroundColor: '#4F46E5',
+    borderColor: '#4F46E5',
+  },
+  frequencyButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+    textAlign: 'center',
+    color: '#4b5563',
+  },
+  selectedFrequencyText: {
+    color: '#fff',
+  },
+  daysContainer: {
+    marginBottom: 16,
+  },
+  daysButtons: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  dayButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#e5e7eb',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  selectedDay: {
+    backgroundColor: '#4F46E5',
+    borderColor: '#4F46E5',
+  },
+  dayButtonText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#4b5563',
+  },
+  selectedDayText: {
+    color: '#fff',
   },
 });

--- a/lifesyncc-mobile/app/services/schedule.service.js
+++ b/lifesyncc-mobile/app/services/schedule.service.js
@@ -106,6 +106,19 @@ class ScheduleService {
     }
   }
 
+  async createRecurringTask(task) {
+    try {
+      const response = await apiService.request('/api/schedule/recurring', {
+        method: 'POST',
+        body: JSON.stringify(task),
+      });
+      return response;
+    } catch (error) {
+      console.error('Error creating recurring task:', error);
+      throw error;
+    }
+  }
+
   formatDateForAPI(date) {
     const year = date.getFullYear();
     const month = String(date.getMonth() + 1).padStart(2, '0');


### PR DESCRIPTION
## Summary
- Added comprehensive recurring task functionality to the mobile app
- Users can now create tasks that repeat daily, weekly, or monthly
- Weekly tasks support specific day selection

## Changes Made

### Mobile App (ScheduleScreenEnhanced)
- Added repeat toggle switch in the Add Task modal
- Added frequency selection buttons (Daily, Weekly, Monthly)
- Added day-of-week selection for weekly recurring tasks
- Updated task creation logic to handle recurring tasks differently

### Backend
- Enhanced `/api/schedule/recurring` endpoint with date format validation
- Added debug logging for troubleshooting
- Properly generates recurring task instances based on recurrence rules

### Schedule Service
- Added `createRecurringTask` method to interface with backend
- Handles proper data formatting for recurring task creation

## Test Plan
- [ ] Create a daily recurring task and verify it appears on subsequent days
- [ ] Create a weekly recurring task with specific days and verify correct appearance
- [ ] Create a monthly recurring task and verify it appears on the same date each month
- [ ] Verify non-recurring tasks still work as expected
- [ ] Test error handling for invalid date formats

## Screenshots
The recurring UI is now visible in the Add Task modal with toggle, frequency selection, and day picker.

🤖 Generated with [Claude Code](https://claude.ai/code)