### PR TITLE
Fix recurring task data structure in mobile app

### DIFF
--- a/lifesyncc-mobile/app/services/schedule.service.js
+++ b/lifesyncc-mobile/app/services/schedule.service.js
@@ -108,14 +108,26 @@ class ScheduleService {
 
   async createRecurringTask(task) {
     try {
+      console.log('Original task data:', JSON.stringify(task, null, 2));
+      
+      // Extract the block data from the task
+      // The task structure might have the block nested or at root level
+      const blockData = task.block || task;
+      
       // Transform the data to match what the API expects
       const requestData = {
         block: {
-          ...task,
+          id: blockData.id,
+          title: blockData.title,
+          category: blockData.category,
+          startTime: blockData.startTime,
+          endTime: blockData.endTime,
+          completed: blockData.completed || false,
           recurring: true,
-          recurrenceRule: task.recurrenceRule
+          recurrenceRule: blockData.recurrenceRule || task.recurrenceRule,
+          recurrenceId: blockData.recurrenceId
         },
-        startDate: task.startDate,
+        startDate: task.startDate || blockData.startDate,
         daysAhead: 90 // Optional, defaults to 90 in API
       };
       


### PR DESCRIPTION
- Added logging to see original task data structure
- Properly extract block properties from task object
- Explicitly map all required fields (title, category, startTime, endTime)
- Handle both nested and flat task data structures
- This ensures all required fields are sent to the API