### PR TITLE
Unify goal creation experience with SchedulePreviewModal

### DIFF
--- a/lifesyncc-mobile/app/screens/main/DashboardScreen.tsx
+++ b/lifesyncc-mobile/app/screens/main/DashboardScreen.tsx
@@ -102,27 +102,35 @@ export const DashboardScreen: React.FC = () => {
       return;
     }
     
-    // Create default goal structure
+    // Create default goal structure for manual mode
     const defaultGoalDetails = {
       title: goalText.trim(),
       category: 'physical',
       description: '',
-      type: 'milestone',
-      priority: 'medium',
+      type: 'milestone' as const,
+      priority: 'medium' as const,
       proposedSchedule: {
         summary: 'Custom schedule',
         explanation: 'Create your own schedule',
         sessions: [{
           activity: goalText.trim(),
-          frequency: 'weekly',
-          daysPerWeek: 1,
+          frequency: 'weekly' as const,
+          daysPerWeek: 3,
           time: '19:00',
           duration: 60,
-          days: ['Mon'],
-          totalOccurrences: 4
+          days: ['Mon', 'Wed', 'Fri'],
+          totalOccurrences: 12,
+          repeat: true,
+          tags: []
         }]
       },
-      isManualMode: true
+      isManualMode: true,
+      scheduleStartDate: new Date().toISOString(),
+      scheduleEndDate: (() => {
+        const date = new Date();
+        date.setDate(date.getDate() + 84); // 12 weeks default
+        return date.toISOString();
+      })()
     };
 
     setGoalDetails(defaultGoalDetails);


### PR DESCRIPTION
## Summary
- Replace form-based GoalCreationModal with SchedulePreviewModal across the app
- Provide consistent UI for creating and editing goals
- Automatically open in edit mode for new goal creation

## Changes Made

### GoalsScreen Updates
- Replaced `GoalCreationModal` import with `SchedulePreviewModal`
- Updated `openGoalModal` to create default goal structure with `isManualMode: true`
- Added handler functions for schedule acceptance, modification, and cancellation
- Set sensible defaults: 3 days/week schedule for 12 weeks

### DashboardScreen Improvements
- Enhanced default values for manual goal creation
- Added schedule dates and improved type safety
- Set repeat flag and tags array for new goals

## Benefits
- **Consistent UX**: Users see the same interface whether creating or editing goals
- **Better defaults**: Pre-populated with reasonable schedule settings
- **Unified flow**: No more switching between different modal styles

## Testing
- [x] Goal creation from Goals screen opens SchedulePreviewModal in edit mode
- [x] Default values are properly set for new goals
- [x] Goal creation flow works end-to-end
- [x] Existing edit functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)