### PR TITLE
fix: remove extra closing brace causing syntax error

### DIFF
--- a/lifesyncc-mobile/app/screens/main/GoalsScreenEnhanced.tsx
+++ b/lifesyncc-mobile/app/screens/main/GoalsScreenEnhanced.tsx
@@ -330,7 +330,6 @@ export const GoalsScreenEnhanced: React.FC = () => {
     const endHours = Math.floor(totalMinutes / 60);
     const endMinutes = totalMinutes % 60;
     return `${endHours.toString().padStart(2, '0')}:${endMinutes.toString().padStart(2, '0')}`;
-  }
   };
 
   const updateGoalProgress = async (goalId: string, newValue: number) => {


### PR DESCRIPTION
Fixed syntax error in GoalsScreenEnhanced where an extra closing brace was causing 'return' statement to be outside of the component function