### PR TITLE
Fix modal close and add background creation notification

### DIFF
--- a/lifesyncc-mobile/app/components/SchedulePreviewModal.tsx
+++ b/lifesyncc-mobile/app/components/SchedulePreviewModal.tsx
@@ -311,6 +311,8 @@ export const SchedulePreviewModal: React.FC<SchedulePreviewModalProps> = ({
     if (goalDetails?.isManualMode) {
       // For manual mode (creating a new goal), use onAccept
       onAccept(updatedDetails);
+      // Close the modal (this was missing!)
+      onCancel();
     } else {
       // For editing existing goal, use onUpdate
       if (onUpdate) {

--- a/lifesyncc-mobile/app/screens/main/DashboardScreen.tsx
+++ b/lifesyncc-mobile/app/screens/main/DashboardScreen.tsx
@@ -140,6 +140,19 @@ export const DashboardScreen: React.FC = () => {
   const handleAcceptSchedule = async () => {
     setIsCreatingGoal(true);
     
+    // Show intermediate creating popup
+    Alert.alert(
+      'Creating Schedule',
+      'Your schedule is being created in the background, you can proceed using the app until it is done.',
+      [
+        {
+          text: 'OK',
+          style: 'default'
+        }
+      ],
+      { cancelable: true }
+    );
+    
     try {
       // Prepare goal data
       const scheduleStartDate = goalDetails.scheduleStartDate ? new Date(goalDetails.scheduleStartDate) : new Date();


### PR DESCRIPTION
## Summary
- Fixed modal not closing in manual mode (goal creation)
- Added notification that schedule is being created in background
- Users can now continue using the app while creation happens

## Problem
1. Modal stayed open after clicking "Save Changes" in goal creation mode
2. No feedback about background processing
3. Users didn't know they could continue using the app

## Solution
1. Fixed missing `onCancel()` call in manual mode - modal now closes immediately
2. Added clear notification: "Your schedule is being created in the background, you can proceed using the app until it is done."
3. Non-blocking alert with OK button

## Changes
- **SchedulePreviewModal.tsx**: Added `onCancel()` call after `onAccept()` in manual mode
- **DashboardScreen.tsx**: Added intermediate alert after modal closes

## Test Plan
- [ ] Create a new goal and fill details
- [ ] Click "Save Changes"
- [ ] Verify modal closes immediately
- [ ] Verify background creation alert appears
- [ ] Click OK to dismiss alert
- [ ] Verify you can navigate and use the app
- [ ] Verify success notification appears when creation completes
- [ ] Test edit mode still works correctly

## User Experience
Before: Modal stayed open, users confused about status
After: Clean flow with clear communication about background processing

🤖 Generated with [Claude Code](https://claude.ai/code)